### PR TITLE
Clone to New Window, Right Click Tabs and Keymap Disabling added

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,12 +1,44 @@
 [
-  { 
-    "keys": ["ctrl+shift+right"], 
-    "command": "simple_clone", 
-    "args": { "direction" : "right"}
-  },
-  { 
-    "keys": ["ctrl+shift+down"], 
-    "command": "simple_clone", 
-    "args": { "direction" : "down"}
-  }
+	{
+		"keys": [
+			"ctrl+shift+right"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "right"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.right"
+			}
+		]
+	},
+	{
+		"keys": [
+			"ctrl+shift+down"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "down"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.down"
+			}
+		]
+	},
+	{
+		"keys": [
+			"ctrl+shift+alt+n"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "new_window"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.new_window"
+			}
+		]
+	}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,12 +1,44 @@
 [
-  { 
-    "keys": ["super+shift+right"], 
-    "command": "simple_clone", 
-    "args": { "direction" : "right"}
-  },
-  { 
-    "keys": ["super+shift+down"], 
-    "command": "simple_clone", 
-    "args": { "direction" : "down"}
-  }
+	{
+		"keys": [
+			"super+shift+right"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "right"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.right"
+			}
+		]
+	},
+	{
+		"keys": [
+			"super+shift+down"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "down"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.down"
+			}
+		]
+	},
+	{
+		"keys": [
+			"super+shift+alt+n"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "new_window"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.new_window"
+			}
+		]
+	}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,12 +1,44 @@
 [
-  { 
-    "keys": ["ctrl+shift+right"], 
-    "command": "simple_clone", 
-    "args": { "direction" : "right"}
-  },
-  { 
-    "keys": ["ctrl+shift+down"], 
-    "command": "simple_clone", 
-    "args": { "direction" : "down"}
-  }
+	{
+		"keys": [
+			"ctrl+shift+right"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "right"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.right"
+			}
+		]
+	},
+	{
+		"keys": [
+			"ctrl+shift+down"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "down"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.down"
+			}
+		]
+	},
+	{
+		"keys": [
+			"ctrl+shift+alt+n"
+		],
+		"command": "simple_clone",
+		"args": {
+			"location": "new_window"
+		},
+		"context": [
+			{
+				"key": "simpleclone_keymap_enabled.new_window"
+			}
+		]
+	}
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,25 +1,73 @@
 [
-{
-  "id": "view",
-  "children":
-  [
-    { "id" : "groups" },
+	{
+		"id": "view",
+		"children": [
+			{
+				"id": "groups"
+			},
+			{
+				"caption": "SimpleClone",
+				"children": [
+					{
+						"command": "simple_clone",
+						"caption": "Split Down",
+						"args": {
+							"location": "down"
+						}
+					},
+					{
+						"command": "simple_clone",
+						"caption": "Split Right",
+						"args": {
+							"location": "right"
+						}
+					},
+					{
+						"command": "simple_clone",
+						"caption": "Clone to New Window",
+						"args": {
+							"location": "new_window"
+						}
+					}
+				]
+			}
+		]
+	},
     {
-      "caption": "SimpleClone",
-      "children":
-      [
-        { 
-          "command" : "simple_clone", 
-          "caption" : "Split Down", 
-          "args" : { "direction" : "down" }
-        },
-        { 
-          "command" : "simple_clone", 
-          "caption" : "Split Right", 
-          "args" : { "direction" : "right" }
-        }
-      ]
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "SimpleClone",
+                        "children":
+                        [
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/SimpleClone/SimpleClone.sublime-settings"
+                                },
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/User/SimpleClone.sublime-settings"
+                                },
+                                "caption": "Settings – User"
+                            },
+                            { "caption": "-" }
+                        ]
+                    }
+                ]
+            }
+        ]
     }
-  ]
-}
 ]

--- a/README.md
+++ b/README.md
@@ -4,17 +4,37 @@ SimpleClone is a Sublime Text 2 plugin for lightning-fast file cloning.
 
 ## Documentation
 
-After installing SimpleClone, clone the active view using two simple shortcuts:
+After installing SimpleClone, clone the active view using these simple shortcuts:
 
 **Windows/Linux**
 
   * Ctrl-Shift-Right to clone the active view to the right.
   * Ctrl-Shift-Down to clone the active view down.
+  * Ctrl-Shift-Alt-N to clone to a new window.
 
 **OSX**
 
   * Super-Shift-Right to clone the active view to the right.
   * Super-Shift-Down to clone the active view down.
+  * Super-Shift-Alt-N to clone to a new window.
+
+You can also clone your view via the View Menu or by right clicking on a file's tab
+
+## Overriding keyboard shortcuts
+
+Sublime Text 2 is a great text editor with lots of features and actions. Most of these actions are bound to keyboard shortcuts so it’s nearly impossible to provide convenient plugin shortcuts for third-party plugins.
+
+If you’re unhappy with default keymap, you can disable individual keyboard shortcuts with disabled_keymaps preference of SimpleClone.sublime-settings file.
+
+Use a comma-separated list of clone locations for which default keyboard shortcuts should be disabled. For example, if you want to release Ctrl+Shift+Right (“Clone to Right View”), you must set the following value:
+
+"disabled_keymaps": "right"
+You should refer Default (Your-OS-Name).sublime-keymap file to get action ids (look for args/action key).
+
+To disable all default shortcuts, set value to all:
+
+"disabled_keymaps": "all"
+Not that if you disabled any action like so and you’re create your own keyboard shortcut, you should not use simpleclone_keymap_enabled.LOCATION_NAME context since this is the key that disables locations.
 
 ## License
 

--- a/SimpleClone.sublime-settings
+++ b/SimpleClone.sublime-settings
@@ -1,0 +1,9 @@
+{
+	// Copy any modified settings to `User/SimpleClone.sublime-settings`
+	// otherwise modifications will not survive updates.
+
+	// A comma-separated list of clone locations to disable keymapping for
+	// Current valid locations: all, right, down, new_window
+	// Use "all" as a convenient way to disable all keymappings
+	"disabled_keymaps": ""
+}

--- a/Tab Context.sublime-menu
+++ b/Tab Context.sublime-menu
@@ -1,0 +1,32 @@
+[
+	{
+		"caption": "-"
+	},
+	{
+		"caption": "Clone to Right View",
+		"command": "simple_clone",
+		"args": {
+			"location": "right",
+			"context": "menu"
+		}
+	},
+	{
+		"caption": "Clone to Bottom View",
+		"command": "simple_clone",
+		"args": {
+			"location": "down",
+			"context": "menu"
+		}
+	},
+	{
+		"command": "simple_clone",
+		"caption": "Clone to New Window",
+		"args": {
+			"location": "new_window",
+			"context": "menu"
+		}
+	},
+	{
+		"caption": "-"
+	}
+]

--- a/simple_clone.py
+++ b/simple_clone.py
@@ -1,71 +1,84 @@
 import sublime
 import sublime_plugin
 
-class SimpleCloneCommand(sublime_plugin.WindowCommand):  
-    def run(self, direction):
-    
-        activeGroup = self.window.active_group()
+import re
+
+
+class SimpleCloneCommand(sublime_plugin.WindowCommand):
+    def run(self, location):  # --Matt Bolt: Renamed direction variable to the more symantically appropriate name 'location' due to additional options
+
+        # activeGroup = self.window.active_group() --Matt Bolt: Commented out unused variable
         layout = self.window.get_layout()
         rows = len(layout['rows']) - 1
         cols = len(layout['cols']) - 1
-    
-        # Start by cloning the file...
-        self.window.run_command('clone_file')
 
-        # Now modify the layout if necessary...
-        if direction == 'down':
-            active = self.window.get_view_index(self.window.active_view())[0]
-            total = self.window.num_groups()
-            
-            if rows > 1:
-                if active == total - 1:
-                    self.window.set_layout(self.createLayout(rows + 1, cols))
-                    newGroup = active + cols
-                else:
-                    total = self.window.num_groups()
-                    if active + cols < total:
-                        newGroup = active + cols
-                    elif active - cols >= 0:
-                        newGroup = active - cols
-                    else:
-                        newGroup = active
-            else:
-                self.window.set_layout(self.createLayout(rows + 1, cols))
+        # Clone to new window if requested
+        if location == 'new_window':
+            # Create new window
+            self.window.run_command("new_window")
+            # Open the current file in the new window
+            sublime.windows()[-1:][0].open_file(self.window.active_view().file_name())
+
+        # Handle cloning to view
+        else:
+
+            # Start by cloning the file...
+            self.window.run_command('clone_file')
+
+            # Now modify the layout if necessary...
+            if location == 'down':
+                active = self.window.get_view_index(self.window.active_view())[0]
                 total = self.window.num_groups()
-                newGroup = active + cols
 
-        elif direction == 'right':
-            active = self.window.get_view_index(self.window.active_view())[0]
-            total = self.window.num_groups()
-            if cols > 1:
-                if active == total - 1:
+                if rows > 1:
+                    if active == total - 1:
+                        self.window.set_layout(self.createLayout(rows + 1, cols))
+                        newGroup = active + cols
+                    else:
+                        total = self.window.num_groups()
+                        if active + cols < total:
+                            newGroup = active + cols
+                        elif active - cols >= 0:
+                            newGroup = active - cols
+                        else:
+                            newGroup = active
+                else:
+                    self.window.set_layout(self.createLayout(rows + 1, cols))
+                    total = self.window.num_groups()
+                    newGroup = active + cols
+
+            elif location == 'right':
+                active = self.window.get_view_index(self.window.active_view())[0]
+                total = self.window.num_groups()
+                if cols > 1:
+                    if active == total - 1:
+                        self.window.set_layout(self.createLayout(rows, cols + 1))
+                        newGroup = active + 1
+                    else:
+                        total = self.window.num_groups()
+                        if active + 1 < total:
+                            newGroup = active + 1
+                        elif active - 1 >= 0:
+                            newGroup = active - 1
+                        else:
+                            newGroup = active
+                else:
                     self.window.set_layout(self.createLayout(rows, cols + 1))
                     newGroup = active + 1
-                else:
-                    total = self.window.num_groups()
-                    if active + 1 < total:
-                        newGroup = active + 1
-                    elif active - 1 >= 0:
-                        newGroup = active - 1
-                    else:
-                        newGroup = active
-            else:
-                self.window.set_layout(self.createLayout(rows, cols + 1))
-                newGroup = active + 1
 
-        # And now move the file to the appropriate group
-        self.window.run_command('move_to_group', { "group" : newGroup })
+            # And now move the file to the appropriate group
+            self.window.run_command('move_to_group', {"group": newGroup})
 
     def createLayout(self, rows, cols):
 
         numCells = rows * cols
-        rowIncrement = 1.0/rows
-        colIncrement = 1.0/cols
+        rowIncrement = 1.0 / rows
+        colIncrement = 1.0 / cols
 
         # Add initial layout arrays
         layoutRows = [0]
         layoutCols = [0]
-        layoutCells = [[0]*4]*numCells
+        layoutCells = [[0] * 4] * numCells
 
         # Create rows array
         if rows > 1:
@@ -75,7 +88,7 @@ class SimpleCloneCommand(sublime_plugin.WindowCommand):
 
         layoutRows.append(1.0)
 
-        # Create columns array
+        # Create columns arraydown
         if cols > 1:
             for y in xrange(1, cols):
                 increment = colIncrement * y
@@ -87,7 +100,32 @@ class SimpleCloneCommand(sublime_plugin.WindowCommand):
         counter = 0
         for a in range(rows):
             for b in range(cols):
-                layoutCells[counter] = [b, a, b+1, a+1]
-                counter+=1
+                layoutCells[counter] = [b, a, b + 1, a + 1]
+                counter += 1
 
-        return { 'cells': layoutCells, 'rows': layoutRows, 'cols': layoutCols }
+        return {'cells': layoutCells, 'rows': layoutRows, 'cols': layoutCols}
+
+
+    # Used to disable keymaps
+def should_perform_clone(location):
+        disabled_keymaps = settings.get('disabled_keymaps', '')
+
+        if not disabled_keymaps:
+            return True
+
+        if disabled_keymaps == 'all':
+            return False
+
+        return location not in re.split(r'\s*,\s*', disabled_keymaps.strip())
+
+
+class ActionContextHandler(sublime_plugin.EventListener):
+    def on_query_context(self, view, key, op, operand, match_all):
+        if not key.startswith('simpleclone_keymap_enabled.'):
+            return None
+
+        prefix, location = key.split('.')
+        return should_perform_clone(location)
+
+
+settings = sublime.load_settings('SimpleClone.sublime-settings')


### PR DESCRIPTION
- Added right click contextual menu items to tabs
- Added a default settings file to allow for disabling keymaps
- Added the ability to clone to a new window
- Tweaked several files syntax (SublimeLinter - it hurts your
  feelings - but makes you code better)
